### PR TITLE
fix: add auto role update for auto config

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
   "scripts": {
     "dev": "npx tsc -w -p tsconfig.json",
     "prebuild": "rimraf dist",
-    "build": "npx tsc -p tsconfig.json",
+    "build": "npm run fix && npm run lint && npx tsc -p tsconfig.json",
     "build:component": "npx webpack --mode=production",
     "publish": "npm run build:component && s platform publish",
     "test": "jest",
     "test:cov": "jest --coverage",
-    "lint": "f2elint scan",
-    "fix": "f2elint fix",
+    "lint": "f2elint scan -i ./src",
+    "fix": "f2elint fix -i ./src",
     "typecheck": "npx tsc -p tsconfig.json --noEmit"
   },
   "husky": {

--- a/src/lib/fc/service.ts
+++ b/src/lib/fc/service.ts
@@ -95,7 +95,8 @@ export class FcService extends FcDeploy<ServiceConfig> {
 
   async generateServiceRole(): Promise<string> {
     const serviceRole: any = this.localConfig.role;
-    if (_.isString(serviceRole)) {
+    // 用户指定 roleArn 时不做任何更新 Role 的处理
+    if (_.isString(serviceRole) && !_.toLower(serviceRole).includes('fcdeploydefaultrole')) {
       const roleName: string = extractRoleNameFromArn(serviceRole);
       this.logger.info(StdoutFormatter.stdoutFormatter.using('role', `extracted name is ${roleName}`));
       return serviceRole;
@@ -114,6 +115,8 @@ export class FcService extends FcDeploy<ServiceConfig> {
     if (_.isNil(serviceRole)) {
       roleName = `fcDeployDefaultRole-${this.localConfig?.name}`;
       roleName = normalizeRoleOrPoliceName(roleName);
+    } else if (_.isString(serviceRole)) {
+      roleName = extractRoleNameFromArn(serviceRole);
     } else {
       roleName = serviceRole.name;
     }

--- a/src/lib/resource/ram.ts
+++ b/src/lib/resource/ram.ts
@@ -68,6 +68,6 @@ export function extractRoleNameFromArn(roleArn: string): string {
 
 export function checkRoleArnFormat(roleArn: string): void {
   if (!roleArn.startsWith('acs:ram::')) {
-    throw new Error(`Invalid format of role arn: ${roleArn}, it should start with \'acs:ram::\'`);
+    throw new Error(`Invalid format of role arn: ${roleArn}, it should start with 'acs:ram::'`);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "exclude": ["node_modules", "test/**.ts", "dist"]
+  "exclude": ["node_modules", "test/**.ts", "dist", "examples"]
 }


### PR DESCRIPTION
当role 为fc-deploy组件创建时，则必然会对其进行检查，必要时进行更新操作。
例如第一次部署 `vpcConfig：auto` 创建了 default  role，该 role 会保存在本地，
第二次部署时再增加 `logConfig: auto` 时，则该 default role 也需要增加日志相关的权限。

若 roleArn 为用户自行配置，则不对该 role 进行任何检查/更新操作。