### PR TITLE
change logic for deploy state

### DIFF
--- a/src/lib/component/fc-info.ts
+++ b/src/lib/component/fc-info.ts
@@ -34,6 +34,8 @@ export default class FcInfoComponent extends Component {
       });
     }
 
+    prop['infoType'] = true
+
     return prop;
   }
 }

--- a/src/lib/fc/function.ts
+++ b/src/lib/fc/function.ts
@@ -342,6 +342,15 @@ export class FcFunction extends FcDeploy<FunctionConfig> {
         }
       });
     }
+
+    // const {remoteConfig} = await this.GetRemoteInfo('function', this.serviceName, this.name, undefined)
+    // // this.statefulConfig = _.cloneDeep(resolvedServiceConf);
+    // this.statefulConfig = remoteConfig
+    // if(this.statefulConfig && this.statefulConfig.lastModifiedTime){
+    //   delete this.statefulConfig.lastModifiedTime
+    // }
+    // this.upgradeStatefulConfig();
+
     return resolvedFunctionConf;
   }
 }

--- a/src/lib/fc/service.ts
+++ b/src/lib/fc/service.ts
@@ -275,7 +275,6 @@ export class FcService extends FcDeploy<ServiceConfig> {
     if (!_.isNil(this.localConfig.internetAccess)) {
       Object.assign(resolvedServiceConf, { internetAccess: this.localConfig.internetAccess });
     }
-
     const role = await this.generateServiceRole();
     if (!_.isEmpty(role)) { Object.assign(resolvedServiceConf, { role }); }
     if (!_.isEmpty(this.localConfig.logConfig)) {
@@ -304,8 +303,13 @@ export class FcService extends FcDeploy<ServiceConfig> {
     }
     // await this.setResolvedConfig(this.name, resolvedServiceConf, this.hasAutoConfig);
     // update stateful config
-    this.statefulConfig = _.cloneDeep(resolvedServiceConf);
-    this.upgradeStatefulConfig();
+    // const {remoteConfig} = await this.GetRemoteInfo('service', this.name, undefined, undefined)
+    // // this.statefulConfig = _.cloneDeep(resolvedServiceConf);
+    // this.statefulConfig = remoteConfig
+    // if(this.statefulConfig && this.statefulConfig.lastModifiedTime){
+    //   delete this.statefulConfig.lastModifiedTime
+    // }
+    // this.upgradeStatefulConfig();
     return resolvedServiceConf;
   }
 }

--- a/src/lib/fc/trigger.ts
+++ b/src/lib/fc/trigger.ts
@@ -6,6 +6,7 @@ import FcDeploy from './fc-deploy';
 import StdoutFormatter from '../component/stdout-formatter';
 
 export interface TriggerConfig {
+  lastModifiedTime: any;
   name: string;
   type: 'oss' | 'log' | 'timer' | 'http' | 'mnsTopic' | 'cdnEvents' | 'tablestore';
   role?: string;
@@ -329,6 +330,7 @@ export class FcTrigger extends FcDeploy<TriggerConfig> {
   }
 
   async makeTrigger(): Promise<TriggerConfig> {
+
     if (this.useRemote) {
       this.statefulConfig = _.cloneDeep(this.remoteConfig);
       this.upgradeStatefulConfig();
@@ -345,9 +347,16 @@ export class FcTrigger extends FcDeploy<TriggerConfig> {
         protect: false,
       });
     }
+
+    const {remoteConfig} = await this.GetRemoteInfo('trigger', this.serviceName, this.functionName, this.name)
+    if(remoteConfig && remoteConfig.lastModifiedTime){
+      delete remoteConfig.lastModifiedTime
+    }
+
     if (!_.isNil(this.localConfig.role) || this.isHttpTrigger() || this.isTimerTrigger()) {
-      this.statefulConfig = _.cloneDeep(resolvedTriggerConf);
-      this.upgradeStatefulConfig();
+      // this.statefulConfig = _.cloneDeep(resolvedTriggerConf);
+      // this.statefulConfig = remoteConfig
+      // this.upgradeStatefulConfig();
       return resolvedTriggerConf;
     }
     const role = await this.makeInvocationRole();
@@ -358,8 +367,11 @@ export class FcTrigger extends FcDeploy<TriggerConfig> {
     this.isRoleAuto = true;
 
     // await this.setResolvedConfig(this.name, resolvedTriggerConf, this.isRoleAuto);
-    this.statefulConfig = _.cloneDeep(resolvedTriggerConf);
-    this.upgradeStatefulConfig();
+    // this.statefulConfig = _.cloneDeep(resolvedTriggerConf);
+
+    // this.statefulConfig = remoteConfig
+    // this.upgradeStatefulConfig();
+
     return resolvedTriggerConf;
   }
 }


### PR DESCRIPTION
1. 更改部署逻辑
    1.1 在部署之前，检测已存在状态的数据和线上数据对比
    1.2 在部署之后，写入线上最新数据以做缓存
2. 更改对比内容
    2.1 不匹配的效果：
![image](https://user-images.githubusercontent.com/21079031/125231441-51b79d80-e30d-11eb-88a4-70936fe52bff.png)
![image](https://user-images.githubusercontent.com/21079031/125231460-5c723280-e30d-11eb-9466-ecf41fc96859.png)

已经测试的Case：
1. 线上不存在函数，进行部署：直接完成部署
2. 线上存在函数，本地全新进行部署：提醒增加的字段
3. 线上已存在本地部署的函数，对线上进行修改：本地给出变化字段