### PR TITLE
perf: support deploy service/function/trigger in pulumi mode

### DIFF
--- a/src/lib/fc/function.ts
+++ b/src/lib/fc/function.ts
@@ -93,7 +93,15 @@ export class FcFunction extends FcDeploy<FunctionConfig> {
     this.serviceName = serviceName;
     this.name = functionConf?.name;
   }
-  async initLocal(assumeYes?: boolean): Promise<void> {
+
+  async init(type: string, useLocal?: boolean, assumeYes?: boolean): Promise<void> {
+    await this.initRemote('function', this.serviceName, this.name);
+    await this.initStateful();
+    await this.initLocal(assumeYes);
+    await this.setUseRemote(this.name, 'function', useLocal, type);
+  }
+
+  private async initLocal(assumeYes?: boolean): Promise<void> {
     this.validateConfig();
     await this.initLocalConfig(assumeYes);
   }
@@ -383,18 +391,6 @@ export class FcFunction extends FcDeploy<FunctionConfig> {
           codeUri: codeZipPath,
         });
       }
-    }
-
-    this.statefulConfig = _.cloneDeep(resolvedFunctionConf);
-    this.upgradeStatefulConfig();
-    // 环境变量中的 true 需要转换为字符串
-    if (!_.isEmpty(this.statefulConfig?.environmentVariables)) {
-      Object.keys(this.statefulConfig?.environmentVariables).forEach((key) => {
-        if (_.isBoolean(this.statefulConfig?.environmentVariables[key])) {
-          // @ts-ignore
-          this.statefulConfig?.environmentVariables[key] = _.toString(this.statefulConfig?.environmentVariables[key]);
-        }
-      });
     }
 
     return resolvedFunctionConf;

--- a/src/lib/fc/service.ts
+++ b/src/lib/fc/service.ts
@@ -49,7 +49,15 @@ export class FcService extends FcDeploy<ServiceConfig> {
     this.name = serviceConf?.name;
   }
 
-  async initLocal(): Promise<void> {
+  async init(useLocal?: boolean): Promise<void> {
+    await this.initRemote('service', this.name);
+    await this.initStateful();
+    await this.initStatefulAutoConfig();
+    await this.initLocal();
+    await this.setUseRemote(this.name, 'service', useLocal);
+  }
+
+  private async initLocal(): Promise<void> {
     this.validateConfig();
     await this.initLocalConfig();
     this.logger.debug(`local service config is: ${JSON.stringify(this.localConfig, null, '  ')} after init.`);
@@ -66,7 +74,7 @@ export class FcService extends FcDeploy<ServiceConfig> {
     }
   }
 
-  async initLocalConfig(): Promise<void> {
+  private async initLocalConfig(): Promise<void> {
     if (_.isEmpty(this.statefulAutoConfig)) { return; }
     const resolvedAutoConfigInState: any = this.statefulAutoConfig || {};
     // transform nasConfig
@@ -349,15 +357,6 @@ export class FcService extends FcDeploy<ServiceConfig> {
         protect: false,
       });
     }
-    // await this.setResolvedConfig(this.name, resolvedServiceConf, this.hasAutoConfig);
-    // update stateful config
-    // const {remoteConfig} = await this.GetRemoteInfo('service', this.name, undefined, undefined)
-    // // this.statefulConfig = _.cloneDeep(resolvedServiceConf);
-    // this.statefulConfig = remoteConfig
-    // if(this.statefulConfig && this.statefulConfig.lastModifiedTime){
-    //   delete this.statefulConfig.lastModifiedTime
-    // }
-    // this.upgradeStatefulConfig();
     return resolvedServiceConf;
   }
 }

--- a/src/lib/fc/trigger.ts
+++ b/src/lib/fc/trigger.ts
@@ -138,7 +138,14 @@ export class FcTrigger extends FcDeploy<TriggerConfig> {
     return `${this.credentials.AccountID}-${this.region}-${this.serviceName}-${this.functionName}-${this.name}`;
   }
 
-  async initLocal(): Promise<void> {
+  async init(useLocal?: boolean): Promise<void> {
+    await this.initRemote('trigger', this.serviceName, this.functionName, this.name);
+    await this.initStateful();
+    await this.initLocal();
+    await this.setUseRemote(this.name, 'trigger', useLocal);
+  }
+
+  private async initLocal(): Promise<void> {
     this.validateConfig();
     await this.initLocalConfig();
     this.logger.debug(`local trigger config is: ${JSON.stringify(this.localConfig, null, '  ')} after init.`);
@@ -356,9 +363,6 @@ export class FcTrigger extends FcDeploy<TriggerConfig> {
     }
 
     if (!_.isNil(this.localConfig.role) || this.isHttpTrigger() || this.isTimerTrigger()) {
-      // this.statefulConfig = _.cloneDeep(resolvedTriggerConf);
-      // this.statefulConfig = remoteConfig
-      // this.upgradeStatefulConfig();
       return resolvedTriggerConf;
     }
     const role = await this.makeInvocationRole();
@@ -367,12 +371,6 @@ export class FcTrigger extends FcDeploy<TriggerConfig> {
     });
     this.logger.debug(`after making invocation role: ${role} for trigger ${this.name}.`);
     this.isRoleAuto = true;
-
-    // await this.setResolvedConfig(this.name, resolvedTriggerConf, this.isRoleAuto);
-    // this.statefulConfig = _.cloneDeep(resolvedTriggerConf);
-
-    // this.statefulConfig = remoteConfig
-    // this.upgradeStatefulConfig();
 
     return resolvedTriggerConf;
   }

--- a/src/lib/utils/prompt.ts
+++ b/src/lib/utils/prompt.ts
@@ -2,6 +2,7 @@ import inquirer from 'inquirer';
 import { Logger } from '@serverless-devs/core';
 import yaml from 'js-yaml';
 import diff from 'variable-diff';
+import _ from 'lodash';
 
 function isInteractiveEnvironment(): boolean {
   return process.stdin.isTTY;
@@ -24,7 +25,7 @@ export async function promptForConfirmContinue(message: string): Promise<boolean
 }
 
 
-export async function promptForConfirmOrDetails(message: string, details: any, source?: any): Promise<boolean> {
+export async function promptForConfirmOrDetails(message: string, details: any, source?: any, choices?: string[], trueChoice?: string): Promise<boolean> {
   if (!isInteractiveEnvironment()) {
     return true;
   }
@@ -56,8 +57,8 @@ ${result}`);
     type: 'list',
     name: 'prompt',
     message,
-    choices: ['yes', 'no'],
+    choices: choices || ['yes', 'no'],
   }]);
 
-  return answers.prompt === 'yes';
+  return _.isNil(trueChoice) ? answers.prompt === 'yes' : answers.prompt === trueChoice;
 }


### PR DESCRIPTION
### Update

1.  --type 参数在 deploy service/trigger 或者 pulumi 场景时不生效
2. 部署时用户选择使用线上配置，则跳过部署
3. 对于线上/线下配置的选择，使用 'use remote'/'use local' 取代之前的 'yes'/'no'