### PR TITLE
fix: fix deploy custom container function without docker error

### DIFF
--- a/src/lib/fc/function.ts
+++ b/src/lib/fc/function.ts
@@ -348,10 +348,12 @@ export class FcFunction extends FcDeploy<FunctionConfig> {
 
   async makeFunctionCode(baseDir: string, pushRegistry?: string, assumeYes?: boolean): Promise<{ codeZipPath?: string; codeOssObject?: string }> {
     this.logger.debug('waiting for making function code.');
-    if (await this.needPushRegistry(pushRegistry)) {
-      const alicloudAcr = new AlicloudAcr(pushRegistry, this.serverlessProfile, this.credentials, this.region);
+    if (isCustomContainerRuntime(this.localConfig?.runtime)) {
       try {
-        await alicloudAcr.pushImage(this.localConfig?.customContainerConfig.image, assumeYes);
+        if (await this.needPushRegistry(pushRegistry)) {
+          const alicloudAcr = new AlicloudAcr(pushRegistry, this.serverlessProfile, this.credentials, this.region);
+          await alicloudAcr.pushImage(this.localConfig?.customContainerConfig.image, assumeYes);
+        }
       } catch (e) {
         handleKnownErrors(e);
         this.logger.warn(`Push image ${this.localConfig.customContainerConfig.image} failed.`);

--- a/src/lib/resource/sls.ts
+++ b/src/lib/resource/sls.ts
@@ -55,6 +55,7 @@ export class AlicloudSls extends AlicloudClient {
       logstore: defaultLogstore,
       enableRequestMetrics: true,
       enableInstanceMetrics: true,
+      logBeginRule: null,
     };
   }
 }


### PR DESCRIPTION
出现不符合预期的行为：部署 custom-container 函数时，若本地 docker 未运行，则会抛错退出，预期是会继续执行。

抛错的原因是因为使用 dockerode 包时，本地需要启动 docker，对 dockerode 的使用需要增加 try/catch 逻辑