### PR TITLE
fix: ensureNasDir vpc config error

### DIFF
--- a/src/lib/component/nas.ts
+++ b/src/lib/component/nas.ts
@@ -41,7 +41,8 @@ export class NasComponent extends Component {
       serviceName: this.assistServiceName,
       vpcConfig: {
         vpcId: this.vpcConfig.vpcId,
-        vSwitchIds: this.vpcConfig.vSwitchIds,
+        // @ts-ignore
+        vSwitchIds: this.vpcConfig.vswitchIds || this.vpcConfig.vSwitchIds,
         securityGroupId: this.vpcConfig.securityGroupId,
       },
       groupId: this.nasGid,


### PR DESCRIPTION
- 确保 nas 目录存在参数传递错误